### PR TITLE
Add host_vars and group_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ In order from highest to lowest:
 * Playbook vars
 * Playbook Role parameter
 * Role var
+* host_vars file variable
 * Inventory Host variable
+* group_vars file variable
 * Inventory Group variable
 * Role default variable
 

--- a/bin/run_playbook
+++ b/bin/run_playbook
@@ -15,4 +15,5 @@ ansible-playbook \
   playbook.yml \
   -i hosts/local.hosts \
   --extra-vars "echo_var='a command line extra var'" \
+  -c local \
   -v

--- a/group_vars/local.yaml
+++ b/group_vars/local.yaml
@@ -1,0 +1,8 @@
+---
+# Group variables can be assigned in the hosts inventory, or in a file in
+# group_vars. The latter have precedence over the former.
+#
+# Higher Precedent: Inventory Host variable
+# Lower Precedent: Inventory Group variable
+#
+echo_var: a group_vars file var

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -1,0 +1,9 @@
+---
+# Host variables can be assigned in the hosts inventory, or in a file in
+# host_vars. The latter have precedence over the former.
+#
+# Higher Precedent: Role var
+# Lower Precedent: Inventory host variable
+#
+echo_var: a host_vars file var
+


### PR DESCRIPTION
- Host variables can be assigned in the hosts inventory, or in a file in host_vars. The latter have precedence over the former.
- Group variables can be assigned in the hosts inventory, or in a file in group_vars. The latter have precedence over the former.
